### PR TITLE
Allow GeoPointZ params. Change not found error to :time_zone_not_found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# Changelog for Tz_World v0.3.0
+
+This is the changelog for Tz_World v0.3.0 released on December 4th, 2019.  For older changelogs please consult the release tag on [GitHub](https://github.com/kimlai/tz_world/tags)
+
+### Breaking Changes
+
+* Changes the error return from `{:error, :timezone_not_found}` to `{:error, :time_zone_not_found}` since both Elixir and Tzdata use `time_zone`.
+
+### Enhancements
+
+* Allows both `%Geo.Point{}` and `%Geo.PointZ{}` as parameters to `TzWorld.timezone_at/1`
+
 # Changelog for Tz_World v0.2.0
 
 This is the changelog for Tz_World v0.2.0 released on November 28th, 2019.  For older changelogs please consult the release tag on [GitHub](https://github.com/kimlai/tz_world/tags)

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ iex> TzWorld.timezone_at(%Geo.Point{coordinates: {3.2, 45.32}})
 iex> TzWorld.timezone_at(3.2, 45.32)
 {:ok, "Europe/Paris"}
 
+iex> TzWorld.timezone_at(%Geo.PointZ{coordinates: {-74.006, 40.7128, 0.0}})
+{:ok, "America/New_York"}
+
 iex> TzWorld.timezone_at(%Geo.Point{coordinates: {1.3, 65.62}})
-{:error, :timezone_not_found}
+{:error, :time_zone_not_found}
 ```

--- a/lib/tz_world.ex
+++ b/lib/tz_world.ex
@@ -4,7 +4,7 @@ defmodule TzWorld do
 
   """
   use GenServer
-  alias Geo.Point
+  alias Geo.{Point, PointZ}
   import TzWorld.Guards
   alias TzWorld.GeoData
 
@@ -45,6 +45,12 @@ defmodule TzWorld do
   """
   @spec timezone_at(Geo.Point.t()) :: {:ok, String.t()} | {:error, String.t()}
   def timezone_at(%Point{} = point) do
+    GenServer.call(__MODULE__, {:timezone_at, point}, @timeout)
+  end
+
+  @spec timezone_at(Geo.PointZ.t()) :: {:ok, String.t()} | {:error, String.t()}
+  def timezone_at(%PointZ{coordinates: {lng, lat, _alt}}) do
+    point = %Point{coordinates: {lng, lat}}
     GenServer.call(__MODULE__, {:timezone_at, point}, @timeout)
   end
 
@@ -96,7 +102,7 @@ defmodule TzWorld do
         |> case do
           %Geo.MultiPolygon{properties: %{tzid: tzid}} -> {:ok, tzid}
           %Geo.Polygon{properties: %{tzid: tzid}} -> {:ok, tzid}
-          nil -> {:error, :timezone_not_found}
+          nil -> {:error, :time_zone_not_found}
         end
       end
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule TzWorld.Mixfile do
   use Mix.Project
 
-  @version "0.2.0"
+  @version "0.3.0"
 
   def project do
     [

--- a/test/tz_world_test.exs
+++ b/test/tz_world_test.exs
@@ -9,11 +9,16 @@ defmodule TzWorldTest do
 
   test "a known lookup failure" do
     assert TzWorld.timezone_at(%Geo.Point{coordinates: {1.3, 65.62}}) ==
-             {:error, :timezone_not_found}
+             {:error, :time_zone_not_found}
   end
 
-  test "an eastern long, northern lat" do
+  test "an eastern lon, northern lat" do
     assert TzWorld.timezone_at(%Geo.Point{coordinates: {103.8198, 1.3521}}) ==
              {:ok, "Asia/Singapore"}
+  end
+
+  test "a western lon, northern lat with GeoPointZ" do
+    assert TzWorld.timezone_at(%Geo.PointZ{coordinates: {-74.006, 40.7128, 0.0}}) ==
+             {:ok, "America/New_York"}
   end
 end


### PR DESCRIPTION
1. Geo data has two forms of points, 2-dimensional and 3-dimensional (includes elevation). This PR supports the 3 dimensional `Geo.PointZ` as well as the current `Geo.Point`.

2. Elixir and Tzdata return `:time_zone_not_found` - that is use of two worlds, `time_zone` instead of the current `timezone`. I believe it is better to be consistent since the meaning is the same.

Comments and suggestions of course welcome.