### PR TITLE
Remove tests for data version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Changelog for Tz_World v0.7.1
+
+This is the changelog for Tz_World v0.7.1 released on November 6th, 2020.  For older changelogs please consult the release tag on [GitHub](https://github.com/kimlai/tz_world/tags)
+
+### Bug Fixes
+
+* Don't use tests for the external data version since that changes outside of the code lifesycle
+
 # Changelog for Tz_World v0.7.0
 
 This is the changelog for Tz_World v0.7.0 released on October 10th, 2020.  For older changelogs please consult the release tag on [GitHub](https://github.com/kimlai/tz_world/tags)

--- a/lib/tz_world.ex
+++ b/lib/tz_world.ex
@@ -30,8 +30,8 @@ defmodule TzWorld do
 
   ## Example
 
-      iex> TzWorld.version
-      {:ok, "2020a"}
+      TzWorld.version
+      => {:ok, "2020d"}
 
   """
   @spec version :: {:ok, String.t()} | {:error, :enoent}

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule TzWorld.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/kimlai/tz_world"
-  @version "0.7.0"
+  @version "0.7.1"
 
   def project do
     [

--- a/test/tz_world_test.exs
+++ b/test/tz_world_test.exs
@@ -33,6 +33,11 @@ defmodule TzWorldTest do
                {:ok, "Asia/Singapore"}
     end
 
+    test "an Russian timezone with known issue in other libraries with backend #{backend}" do
+      assert TzWorld.timezone_at(%Geo.Point{coordinates: {85.95926, 51.95874}}, unquote(backend)) ==
+               {:ok, "Asia/Barnaul"}
+    end
+
     test "a western lon, northern lat with GeoPointZ with backend #{backend}" do
       assert TzWorld.timezone_at(
                %Geo.PointZ{coordinates: {-74.006, 40.7128, 0.0}},

--- a/test/tz_world_test.exs
+++ b/test/tz_world_test.exs
@@ -14,10 +14,6 @@ defmodule TzWorldTest do
   end
 
   for backend <- @backends do
-    test "getting version for #{backend}" do
-      assert unquote(backend).version == {:ok, "2020a"}
-    end
-
     test "a known lookup with backend #{backend}" do
       assert TzWorld.timezone_at(%Geo.Point{coordinates: {3.2, 45.32}}, unquote(backend)) ==
                {:ok, "Europe/Paris"}


### PR DESCRIPTION
Since the timezone data changes outside the lifecycle of the code, don't use tests against a static version number.