### PR TITLE
Update version on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add `tz_world` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:tz_world, "~> 0.5.0"}
+    {:tz_world, "~> 0.7.0"}
   ]
 end
 ```


### PR DESCRIPTION
The version range didn't match the latest version and I spent to much time understanding why I had issues that should have been already fixed. :see_no_evil: 

Otherwise use
```elixir
{:tz_world, "~> 0.7"}
```
?