### PR TITLE
Add --include_oceans option to mix task tz_world.update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Changelog for Tz_World
 
+## Tz_World v1.1.1
+
+This is the changelog for Tz_World v1.1.1 released on October 12th, 2022.  For older changelogs please consult the release tag on [GitHub](https://github.com/kimlai/tz_world/tags)
+
+### Bug Fixes
+
+* Fix `TzWorld.Backend.Dets` to not raise an exception if there is no timezone data available.
+
 ## Tz_World v1.1.0
 
 This is the changelog for Tz_World v1.1.0 released on August 26th, 2022.  For older changelogs please consult the release tag on [GitHub](https://github.com/kimlai/tz_world/tags)

--- a/lib/tz_world/backend/dets.ex
+++ b/lib/tz_world/backend/dets.ex
@@ -97,7 +97,12 @@ defmodule TzWorld.Backend.Dets do
 
   @doc false
   def handle_continue(:open_dets_file, _state) do
-    {:noreply, get_geodata_table()}
+    case get_geodata_table() do
+     {:error, {:file_error, _, :enoent}} ->
+       {:noreply, {:error, :enoent}}
+     {:ok, __MODULE__} ->
+       {:noreply, {:ok, __MODULE__}}
+    end
   end
 
   @doc false

--- a/lib/tz_world/downloader.ex
+++ b/lib/tz_world/downloader.ex
@@ -10,21 +10,26 @@ defmodule TzWorld.Downloader do
 
   @release_url "https://api.github.com/repos/evansiroky/timezone-boundary-builder/releases"
   @timezones_geojson "timezones.geojson.zip"
+  @timezones_with_oceans_geojson "timezones-with-oceans.geojson.zip"
 
   @doc """
   Return the `{release_number, download_url}` of
   the latest timezones geo JSON data
 
   """
-  def latest_release do
+  def latest_release(include_oceans? \\ false) do
     with {:ok, releases} <- get_releases() do
       release = hd(releases)
       release_number = Map.get(release, "name")
-      timezones_geojson_asset = find_asset(release, @timezones_geojson)
+      asset_name = asset_name(include_oceans?)
+      timezones_geojson_asset = find_asset(release, asset_name)
       asset_url = Map.get(timezones_geojson_asset, "browser_download_url")
       {release_number, asset_url}
     end
   end
+
+  defp asset_name(true), do: @timezones_with_oceans_geojson
+  defp asset_name(false), do: @timezones_geojson
 
   @doc """
   Returns the current installed timezones geo JSON

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule TzWorld.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/kimlai/tz_world"
-  @version "1.1.0"
+  @version "1.1.1"
 
   def project do
     [


### PR DESCRIPTION
Adds support to use the geojson data that includes oceans. Several timezone extend into non-territorial waters and thats valuable for some use cases, for example in the case of issue #23.

Before release this code needs:

1. tests to be updated
2. a means of tracking which data set is being used so that updating data in place will work correctly.
