### PR TITLE
Add a config for httpc options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Changelog for Tz_World
 
+## Tz_World v1.2.1
+
+This is the changelog for Tz_World v1.2.1 released on March 31th, 2023.  For older changelogs please consult the release tag on [GitHub](https://github.com/kimlai/tz_world/tags)
+
+### Enhancements
+
+* Add httpc [set_options/1](https://www.erlang.org/doc/man/httpc.html#set_options-1) support.
+
 ## Tz_World v1.2.0
 
 This is the changelog for Tz_World v1.2.0 released on October 12th, 2022.  For older changelogs please consult the release tag on [GitHub](https://github.com/kimlai/tz_world/tags)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add `tz_world` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:tz_world, "~> 1.0"}
+    {:tz_world, "~> 1.2.1"}
   ]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ with `mix tz_world.update` all calls to `TzWorld.timezone_at/1` will return
 
 ### Configuration
 
-There is no mandatory configuration required however two options may be configured in `config.exs`:
+There is no mandatory configuration required however three options may be configured in `config.exs`:
 
 ```elixir
 config :tz_world,
@@ -38,9 +38,12 @@ config :tz_world,
   # The default is either the trust store included in the
   # libraries `CAStore` or `certifi` or the platform
   # trust store.
-  cacertfile: "path/to/ca_trust_store"
-```
-
+  cacertfile: "path/to/ca_trust_store",
+  # The default is no options, however one can set any `httpc` client options.
+  httpc_opts: [
+    proxy: {{String.to_charlist(proxy_host), proxy_port}, []}
+  ]
+```    
 ## Backend selection
 
 `TzWorld` provides alternative strategies for managing access to the backend data. Each backend is implemented as a `GenServer` that needs to be either manually started with `BackendModule.start_link/1` or preferably added to your application's supervision tree.

--- a/lib/tz_world/downloader.ex
+++ b/lib/tz_world/downloader.ex
@@ -126,6 +126,8 @@ defmodule TzWorld.Downloader do
   defp get_url(url) do
     require Logger
 
+    :httpc.set_options(httpc_opts())
+
     case  :httpc.request(:get, {url, headers()}, https_opts(), []) do
       {:ok, {{_version, 200, 'OK'}, _headers, body}} ->
         {:ok, :erlang.list_to_binary(body)}
@@ -226,6 +228,10 @@ defmodule TzWorld.Downloader do
 
   defp raise_if_no_cacertfile(file) do
     file
+  end
+
+  defp httpc_opts do
+    Application.get_env(TzWorld.app_name(), :httpc_opts, [])
   end
 
   defp https_opts do

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule TzWorld.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/kimlai/tz_world"
-  @version "1.2.0"
+  @version "1.2.1"
 
   def project do
     [


### PR DESCRIPTION
Aims to add a way to pass custom options to the default `httpc` client by adding a new config to the application.

This would be particularly useful when one has to use a proxy to request boundaries of the world's timezones, for example (our use case).