### PR TITLE
Fix erlef/setup-elixir on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,7 @@ on:
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
-
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Setup elixir

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Setup elixir


### PR DESCRIPTION
Forces ubuntu-20.04 instead of the latest version, since it's the latest which has compatibility for OTP 24.1 https://github.com/erlef/setup-beam#compatibility-between-operating-system-and-erlangotp 